### PR TITLE
Create binarize default and accurately compare topologies in tree2Paths

### DIFF
--- a/R/RERfuncs.R
+++ b/R/RERfuncs.R
@@ -739,14 +739,14 @@ nameEdges=function(tree){
 tree2Paths=function(tree, treesObj, binarize=NULL){
   stopifnot(class(tree)[1]=="phylo")
   stopifnot(class(treesObj)[2]=="treesObj")
-  stopifnot(all.equal(tree, treesObj, use.edge.length=F))
+  stopifnot(all.equal.phylo(tree, treesObj$masterTree, use.edge.length=F)) #check for concordant topologies between phenotype and master trees (ignore branch lengths)
 
-  isbinarypheno <- sum(tree$edge.length %in% c(0,1)) == length(tree$edge.length)
-  if (!is.null(binarize)) {
+  isbinarypheno <- sum(tree$edge.length %in% c(0,1)) == length(tree$edge.length) #Is the phenotype tree binary or continuous?
+  if (is.null(binarize)) { #unless specified, determine default for binarize based on type of phenotype tree
     if (isbinarypheno) {
-      binarize = T
+      binarize = T #default for binary phenotype trees: set all positive paths = 1
     } else {
-      binarize = F
+      binarize = F #default for continuous phenotype trees: do not convert to binary
     }
   }
 


### PR DESCRIPTION
This update implements the following suggested fixes suggested by @raghavendranpartha
from the pull request for 'ModifyPathCreation':

- Uses is.null(binarize) to force setting a default for 'binarize'

- Checks topologies by correctly specifying the masterTree within treesObj

It does not implement the following suggestion:

- Changing from all.equal.phylo() to base::all.equal to check topologies

The 'ape' implementation of all.equal() specifically checks for concordant topologies,
so it should be preferable to the base check of object equality.

I have checked that this version succeeds for a binary phenotype tree created using
the master tree topology and fails when the binary phenotype tree has a different topology
(specifically when it is a pruned tree).