### PR TITLE
Issue39

### DIFF
--- a/R/RERfuncs.R
+++ b/R/RERfuncs.R
@@ -226,7 +226,8 @@ computeWeightsAllVar=function (mat, nv=NULL, transform="none",plot = T, predicte
     qqdiff=diff(qq)
     breaks=qq[1:nbreaks]+qqdiff/2
     rr=quantile(mml, c(0.0001, 0.99))
-    breaks=round(breaks,3)
+    #breaks=round(breaks,3)
+    breaks=unique(round(breaks,3)) #forces unique breaks
     cutres<-cut(mml,breaks = breaks)
 
     cutres_tt=table(cutres)
@@ -591,6 +592,7 @@ getAllCor=function(RERmat, charP, method="auto",min.sp=10, min.pos=2, winsorizeR
 #' @param scale Scale relative rates internally for each species subset. Increases computation time with little apparent benefit. Better to scale the final matrix.
 #' @param doOnly The index of a specific tree in the treesObj to calculate RER for. Useful if a single result is needed quickly.
 #' @param maxT The maximum number of trees to compute results for. Since this function takes some time this is useful for debugging.
+#' @param plot Whether to plot the output of the correction for mean-variance relationship.
 #' @return A numer of trees by number of paths matrix of relative evolutionary rates. Only an independent set of paths has non-NA values for each tree.
 #' @export
 getAllResiduals=function(treesObj, cutoff=NULL, transform="sqrt", weighted=T,  useSpecies=NULL,  min.sp=10, scale=T,  doOnly=NULL, maxT=NULL, scaleForPproj=F, mean.trim=0.05, plot=T){

--- a/R/RERfuncs.R
+++ b/R/RERfuncs.R
@@ -228,6 +228,7 @@ computeWeightsAllVar=function (mat, nv=NULL, transform="none",plot = T, predicte
     rr=quantile(mml, c(0.0001, 0.99))
     #breaks=round(breaks,3)
     breaks=unique(round(breaks,3)) #forces unique breaks
+    nbreaks=length(breaks)
     cutres<-cut(mml,breaks = breaks)
 
     cutres_tt=table(cutres)


### PR DESCRIPTION
Revised to address a minor issue with plotting before/after distributions of branch lengths when using weighted regression for correcting for mean-variance relationship (heteroscedasticity). Now define breaks for plots using unique values to avoid an error, and also allow user to turn plotting off.