### PR TITLE
Makevars C++14

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,13 +1,4 @@
-
-## With R 3.1.0 or later, you can uncomment the following line to tell R to 
-## enable compilation with C++11 (where available)
-##
-## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
-## availability of the package we do not yet enforce this here.  It is however
-## recommended for client packages to set it.
-##
-## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
-## support within Armadillo prefers / requires it
+## Force C++14 as Armadillo requires at least C++14
 CXX_STD = CXX14
 
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 

--- a/src/Makevars
+++ b/src/Makevars
@@ -8,7 +8,7 @@
 ##
 ## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
 ## support within Armadillo prefers / requires it
-CXX_STD = CXX11
+CXX_STD = CXX14
 
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
 PKG_LIBS = $(SHLIB_OPENMP_CFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
Hi, I was unable to compile RERconverge using a new version of Armadillo due to an error that said that it now requires at least C++14. Changing the CXX_STD = CXX11 to CXX_STD = CXX14 allowed it to successfully compile. Perhaps it is good to replace this, or else remove it entirely from Makevars?